### PR TITLE
Locate user via geolocation API

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -5,6 +5,7 @@ import ErrorComponent from "./ErrorComponent";
 import ResultsComponent from "./ResultsComponent";
 import SearchComponent from "./SearchComponent";
 import RequiredItems from "./RequiredItems";
+import useLocation from "../Hooks/useLocation";
 import Map from "./Map";
 
 export default function App() {
@@ -13,6 +14,26 @@ export default function App() {
   const [city, setCity] = useState("New York City")
   const [results, setResults] = useState(null);
 
+  const geolocateUser = useLocation();
+
+  // Fetch data based on geolocation
+  useEffect(() => {
+    if (geolocateUser.length !== 0) {
+      fetch(`http://api.openweathermap.org/geo/1.0/reverse?lat=${geolocateUser[0]}&lon=${geolocateUser[1]}&limit=1&appid=${process.env.REACT_APP_APIKEY}`)
+        .then(res => res.json())
+        .then(
+          (result) => {
+            setCity(result[0].name);
+          },
+          (error) => {
+            setIsLoaded(true);
+            setError(error);
+          }
+        )
+    }
+  }, [geolocateUser]);
+
+  // Fetch data based on user input
   useEffect(() => { // weather
     fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${process.env.REACT_APP_APIKEY}`)
       .then(res => res.json())

--- a/src/Components/Map.js
+++ b/src/Components/Map.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import mapboxgl from 'mapbox-gl'; // eslint-disable-line import/no-webpack-loader-syntax 
+import mapboxgl from '!mapbox-gl'; // eslint-disable-line import/no-webpack-loader-syntax 
 
 mapboxgl.accessToken = 'pk.eyJ1Ijoicm95Z2JldiIsImEiOiJjbDFjYzF2ajUwMHgzM2NwcXBzdWVxM3ZvIn0.2k8N-UN2Y7ZdT5vwml9QAw';
 

--- a/src/Components/Map.js
+++ b/src/Components/Map.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import mapboxgl from '!mapbox-gl'; // eslint-disable-line import/no-webpack-loader-syntax 
+import mapboxgl from 'mapbox-gl'; // eslint-disable-line import/no-webpack-loader-syntax 
 
 mapboxgl.accessToken = 'pk.eyJ1Ijoicm95Z2JldiIsImEiOiJjbDFjYzF2ajUwMHgzM2NwcXBzdWVxM3ZvIn0.2k8N-UN2Y7ZdT5vwml9QAw';
 

--- a/src/Hooks/useLocation.js
+++ b/src/Hooks/useLocation.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+const useLocation = () => {
+  const [userCoords, setUserCoords] = useState([]);
+  
+  const success = (pos) => {
+    setUserCoords([pos.coords.latitude, pos.coords.longitude])
+  }
+
+  const error = (error) => {
+    console.warn(error);
+  }
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(success, error)
+  }, []);
+
+  return userCoords;
+};
+
+export default useLocation;


### PR DESCRIPTION
For issue #3 Use the geolocation API.

Introduces a `useLocation` hook with the geolocation API and feeds back into a `useEffect` that reverse geocodes the coordinates to a city.

Default city is kept as New York in case user rejects geolocation request.