### PR TITLE
scripts to add homepage on deploying to gh pages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,10 +32,7 @@ jobs:
     - name: Install Dependencies
       run: npm i
 
-    - name: Build Project
-      run: npm run build
-
-    - name: Deploy Project
+    - name: Build & Deploy Project
       run: |
         git config --global user.name $user_name
         git config --global user.email $user_email

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "predeploy": "node scripts/gh-pages-homepage-add.js && npm run build",
     "deploy": "gh-pages -d build",
+    "postdeploy": "node scripts/gh-pages-homepage-delete.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/scripts/gh-pages-homepage-add.js
+++ b/scripts/gh-pages-homepage-add.js
@@ -1,0 +1,7 @@
+const fs = require('fs')
+
+let packageText = fs.readFileSync('./package.json').toString()
+let packageJSON = JSON.parse(packageText);
+packageJSON.homepage = "."
+fs.writeFileSync('./package.json', JSON.stringify(packageJSON, null, 2))
+console.log("Homepage added to package.json")

--- a/scripts/gh-pages-homepage-delete.js
+++ b/scripts/gh-pages-homepage-delete.js
@@ -1,0 +1,7 @@
+const fs = require('fs')
+
+let packageText = fs.readFileSync('./package.json').toString()
+let packageJSON = JSON.parse(packageText);
+delete packageJSON.homepage
+fs.writeFileSync('./package.json', JSON.stringify(packageJSON, null, 2))
+console.log("Homepage removed from package.json")


### PR DESCRIPTION
Added scripts to add homepage field on deploying to github and removing it afterwards.

This should make the repo work with both netlify and github pages.