### PR TITLE
Fixed background and footer gap

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -73,6 +73,7 @@ export default function App() {
   } else {
     return (
       <>
+      <div className="page-container">
         <div className={(isLoaded && results) ? background : undefined}>
           <img className="logo" src={logo} alt="MLH Prep Logo"></img>
           <h2>Enter a city below 👇</h2>
@@ -85,6 +86,7 @@ export default function App() {
           <Map setIsLoaded={setIsLoaded} setResults={setResults} setError={setError} coords={coords} />
           <Footer />
         </div>
+      </div>
       </>
     )
   }

--- a/src/Components/Footer/Footer.js
+++ b/src/Components/Footer/Footer.js
@@ -5,10 +5,13 @@ export default function Footer({}) {
   return (
     <>
       <div className="footer">
+      <div className="footer-content">
         <img className="mlh-prep-logo" src={logo} alt="MLH Prep Logo"></img>
         <div className="footer-text">
           <p>© 2022 Hack2Together</p>
         </div>
+      </div>
+        
         
       </div>
     </>

--- a/src/Components/Footer/footer.css
+++ b/src/Components/Footer/footer.css
@@ -1,29 +1,34 @@
 .footer {
   margin-top: 1rem;
-  padding: 8rem 0rem 2rem 0rem;
+  padding: 4rem 0rem 1rem 0rem;
   background-image: url("../../assets/city2.png");
   background-size: contain;
-  /* background-color: #133667; */
-  position: relative;
+  background-position: bottom;
+  background-repeat: repeat-x;
   display: flex;
   bottom: 0;
   left: 0;
   width: 100%; 
-  height: auto;
-  /* text-align: bottom; */
-  /* justify-content:flex-start; */
-  
+  height: 100%;
+}
+
+.footer-content {
+  margin-top: 1rem;
+  padding: 4rem 0rem 0rem 4rem;
+  text-align: left;
+  justify-content: center;
 }
 
 .mlh-prep-logo {
-  width: 10%;
-  height: 10%;
-  padding: 4rem 0rem 0rem 4rem;
-  margin-top: 10px;
+  width: 20%;
+  height: auto;
+  margin-top: 1rem;
+
+  padding: 4rem 0rem 0rem 0rem;
   object-fit: cover;
 }
 
-.footer-text {
-  padding: 4rem 0rem 0rem 2rem;
-
+.footer-content.footer-text {
+  width: auto;
+  height: au
 }

--- a/src/assets/styles/App.css
+++ b/src/assets/styles/App.css
@@ -11,6 +11,11 @@ body {
   width: 20%;
 }
 
+.page-container {
+  position: relative;
+  min-height: 100vh;
+}
+
 .card-container {
   display: flex;
   flex-direction: row;
@@ -35,7 +40,6 @@ body {
   transition: 0.5s ease-out;
   height: 100%;
   padding-top: 20px;
-  padding-bottom: 20px;
 }
 
 .Mist {


### PR DESCRIPTION
Fixed the styling gap issues between the background image and footer. Closes #53. Also made some additional styling on footer's content.

Before:
<img width="1098" alt="Screen Shot 2022-08-17 at 4 22 20 PM" src="https://user-images.githubusercontent.com/77468763/185236365-48e5413c-f2d8-4a4d-bacc-43acd9e866e7.png">

After: 
<img width="1098" alt="Screen Shot 2022-08-17 at 4 25 28 PM" src="https://user-images.githubusercontent.com/77468763/185236396-fb9fb474-3bf5-4234-bd1e-10fa5fea67d9.png">
